### PR TITLE
fix: massive plugin log payloads

### DIFF
--- a/TebexOxide/BaseTebexAdapter.cs
+++ b/TebexOxide/BaseTebexAdapter.cs
@@ -691,6 +691,18 @@ namespace Tebex.Adapters
             {
                 return;
             }
+
+            // Make sure we don't try to report triage events about ourselves if the triage API has failed.
+            string requestUrl = "";
+            var requestIncluded = autoTriageEvent.Metadata.TryGetValue("request", out requestUrl);
+            if (requestUrl == null)
+            {
+                requestUrl = "";
+            }
+            if (requestIncluded && requestUrl.Contains(TebexApi.TebexTriageUrl))
+            {
+                return;
+            }
             
             // Determine store name
             // Determine the store info, if we have it.

--- a/TebexOxide/Tebex.cs
+++ b/TebexOxide/Tebex.cs
@@ -7,7 +7,7 @@ using Tebex.Triage;
 
 namespace Oxide.Plugins
 {
-    [Info("Tebex", "Tebex", "2.0.3")]
+    [Info("Tebex", "Tebex", "2.0.4")]
     [Description("Official support for the Tebex server monetization platform")]
     public class Tebex : CovalencePlugin
     {
@@ -17,7 +17,7 @@ namespace Oxide.Plugins
 
         public static string GetPluginVersion()
         {
-            return "2.0.3";
+            return "2.0.4";
         }
 
         private void Init()


### PR DESCRIPTION
It would seem if a queued web request to our plugin logs failed, it would continually try to send more triage logs to the same non-working endpoint until the server crashed. also, in some cases we assumed the response would be json, and on some errors we might get an html document. now we handle this appropriately.